### PR TITLE
feat(auth): implementação de autenticação e controle de sessões de simulação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Thumbs.db
 .vscode/
 .idea/
 *.swp
+
+*.iml

--- a/backend_telemetry/pom.xml
+++ b/backend_telemetry/pom.xml
@@ -1,26 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.2.4</version>
         <relativePath/>
     </parent>
+
     <groupId>br.com.justina</groupId>
     <artifactId>backend_telemetry</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>justina-backend</name>
+    <name>backend_telemetry</name>
+    <description>Projeto Justina Backend</description>
+
     <properties>
         <java.version>21</java.version>
-        <spring-cloud.version>2023.0.0</spring-cloud.version>
     </properties>
+
     <dependencies>
+        <!-- Web REST -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <!-- JPA + Banco de dados -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -35,33 +42,61 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Bean Validation -->
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- PasswordEncoder -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- Testes -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+
         </plugins>
     </build>
+
+
 </project>

--- a/backend_telemetry/pom.xml
+++ b/backend_telemetry/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -18,16 +19,16 @@
 
     <properties>
         <java.version>21</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencies>
-        <!-- Web REST -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- JPA + Banco de dados -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -43,13 +44,11 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Bean Validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-        <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -57,14 +56,11 @@
             <scope>provided</scope>
         </dependency>
 
-
-        <!-- PasswordEncoder -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
-        <!-- Testes -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -74,12 +70,13 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
+                    <source>21</source>
+                    <target>21</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
@@ -94,9 +91,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
         </plugins>
     </build>
-
-
 </project>

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginRequest.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package br.com.justina.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginResponse.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package br.com.justina.application.dto;
+
+public record LoginResponse(
+        String name,
+        String email,
+        String role
+) {}

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginResponse.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/LoginResponse.java
@@ -1,6 +1,7 @@
 package br.com.justina.application.dto;
 
 public record LoginResponse(
+        String token,
         String name,
         String email,
         String role

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/RegisterRequest.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/RegisterRequest.java
@@ -1,0 +1,14 @@
+package br.com.justina.application.dto;
+
+import br.com.justina.domain.model.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(
+
+        @NotBlank String name,
+        @Email @NotBlank String email,
+        @NotBlank String password,
+        Role role
+
+) {}

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/SessaoResponse.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/SessaoResponse.java
@@ -1,0 +1,13 @@
+package br.com.justina.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SessaoResponse(
+        UUID id,
+        String status,
+        LocalDateTime dataInicio,
+        Double pontuacaoGeral,
+        Integer totalErros,
+        Long tempoTotalSegundos
+) {}

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/AbrirSessaoUseCase.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/AbrirSessaoUseCase.java
@@ -1,0 +1,56 @@
+package br.com.justina.application.usecases;
+
+import br.com.justina.application.dto.SessaoResponse;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import br.com.justina.domain.model.Usuario;
+import br.com.justina.domain.repository.SessaoSimulacaoRepository;
+import br.com.justina.domain.repository.UsuarioRepository;
+import br.com.justina.infrastructure.exception.AuthenticationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j; // Import do Log
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AbrirSessaoUseCase {
+
+    private final SessaoSimulacaoRepository sessaoRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional
+    public SessaoResponse executar() {
+        String emailLogado = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Usuario usuario = usuarioRepository.findByEmail(emailLogado)
+                .orElseThrow(() -> {
+                    log.error("Tentativa de abrir sessão para usuário inexistente: {}", emailLogado);
+                    return new AuthenticationException("Usuário não encontrado.");
+                });
+
+        if (sessaoRepository.existsByUsuarioAndStatus(usuario, StatusSessao.EM_ANDAMENTO)) {
+            log.warn("Bloqueada tentativa de múltiplas sessões para o usuário: {}", emailLogado);
+            throw new IllegalStateException("O usuário já possui uma simulação em andamento.");
+        }
+
+        SessaoSimulacao novaSessao = SessaoSimulacao.builder()
+                .usuario(usuario)
+                .build();
+
+        SessaoSimulacao salva = sessaoRepository.save(novaSessao);
+
+        log.info("Sessão iniciada com sucesso. ID: {} | Usuário: {}", salva.getId(), emailLogado);
+
+        return new SessaoResponse(
+                salva.getId(),
+                salva.getStatus().name(),
+                salva.getDataInicio(),
+                salva.getPontuacaoGeral(),
+                salva.getTotalErros(),
+                salva.getTempoTotalSegundos()
+        );
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/FinalizarSessaoUseCase.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/FinalizarSessaoUseCase.java
@@ -1,0 +1,56 @@
+package br.com.justina.application.usecases;
+
+import br.com.justina.application.dto.SessaoResponse;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import br.com.justina.domain.repository.SessaoSimulacaoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinalizarSessaoUseCase {
+
+    private final SessaoSimulacaoRepository sessaoRepository;
+
+    @Transactional
+    public SessaoResponse executar(UUID sessaoId) {
+        // 1. Busca a sessão
+        SessaoSimulacao sessao = sessaoRepository.findById(sessaoId)
+                .orElseThrow(() -> new IllegalArgumentException("Sessão não encontrada com o ID: " + sessaoId));
+
+        // 2. Verifica se já não está finalizada
+        if (sessao.isFinalizada()) {
+            throw new IllegalStateException("Esta sessão já foi finalizada anteriormente.");
+        }
+
+        // 3. Define a data de fim e status
+        sessao.setDataFim(LocalDateTime.now());
+        sessao.setStatus(StatusSessao.FINALIZADA);
+
+        // 4. Calcula o tempo total em segundos - Lógica simples por enquanto
+        long segundos = Duration.between(sessao.getDataInicio(), sessao.getDataFim()).getSeconds();
+        sessao.setTempoTotalSegundos(segundos);
+
+        // 5. Salva as alterações
+        SessaoSimulacao salva = sessaoRepository.save(sessao);
+
+        log.info("Sessão {} finalizada. Duração: {} segundos.", salva.getId(), segundos);
+
+        return new SessaoResponse(
+                salva.getId(),
+                salva.getStatus().name(),
+                salva.getDataInicio(),
+                salva.getPontuacaoGeral(),
+                salva.getTotalErros(),
+                salva.getTempoTotalSegundos()
+        );
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
@@ -1,7 +1,9 @@
 package br.com.justina.application.usecases;
 
+import br.com.justina.application.dto.RegisterRequest;
 import br.com.justina.domain.model.Usuario;
 import br.com.justina.domain.repository.UsuarioRepository;
+import br.com.justina.infrastructure.exception.AuthenticationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,20 +19,30 @@ public class UsuarioService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public Usuario register(Usuario usuario) {
-        if (usuarioRepository.existsByEmail(usuario.getEmail())) {
-            throw new IllegalArgumentException("Email já cadastrado!");
+    public void register(RegisterRequest request) {
+
+        if (usuarioRepository.existsByEmail(request.email())) {
+            throw new AuthenticationException("Email ou senha inválidos");
+
         }
-        usuario.setPassword(passwordEncoder.encode(usuario.getPassword()));
-        return usuarioRepository.save(usuario);
+
+        Usuario usuario = new Usuario();
+        usuario.setName(request.name());
+        usuario.setEmail(request.email());
+        usuario.setPassword(passwordEncoder.encode(request.password()));
+        usuario.setRole(request.role());
+
+        usuarioRepository.save(usuario);
     }
+
 
     public Usuario authenticate(String email, String rawPassword) {
         Usuario usuario = usuarioRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("Email ou senha inválidos"));
 
         if (!passwordEncoder.matches(rawPassword, usuario.getPassword())) {
-            throw new IllegalArgumentException("Email ou senha inválidos");
+            throw new AuthenticationException("Email ou senha inválidos");
+
         }
 
         return usuario;

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
@@ -20,10 +20,8 @@ public class UsuarioService {
 
     @Transactional
     public void register(RegisterRequest request) {
-
-        if (usuarioRepository.existsByEmail(request.email())) {
-            throw new AuthenticationException("Email ou senha inválidos");
-
+        if (usuarioRepository.findByEmail(request.email()).isPresent()) {
+            throw new RuntimeException("Este e-mail já está cadastrado.");
         }
 
         Usuario usuario = new Usuario();
@@ -35,16 +33,10 @@ public class UsuarioService {
         usuarioRepository.save(usuario);
     }
 
-
     public Usuario authenticate(String email, String rawPassword) {
-        Usuario usuario = usuarioRepository.findByEmail(email)
+        return usuarioRepository.findByEmail(email)
+                .filter(user -> passwordEncoder.matches(rawPassword, user.getPassword()))
                 .orElseThrow(() -> new AuthenticationException("Email ou senha inválidos"));
-
-        if (!passwordEncoder.matches(rawPassword, usuario.getPassword())) {
-            throw new AuthenticationException("Email ou senha inválidos");
-        }
-
-        return usuario;
     }
 
     public Optional<Usuario> findByEmail(String email) {

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
@@ -1,0 +1,42 @@
+package br.com.justina.application.usecases;
+
+import br.com.justina.domain.model.Usuario;
+import br.com.justina.domain.repository.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UsuarioService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Usuario register(Usuario usuario) {
+        if (usuarioRepository.existsByEmail(usuario.getEmail())) {
+            throw new IllegalArgumentException("Email já cadastrado!");
+        }
+        usuario.setPassword(passwordEncoder.encode(usuario.getPassword()));
+        return usuarioRepository.save(usuario);
+    }
+
+    public Usuario authenticate(String email, String rawPassword) {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Email ou senha inválidos"));
+
+        if (!passwordEncoder.matches(rawPassword, usuario.getPassword())) {
+            throw new IllegalArgumentException("Email ou senha inválidos");
+        }
+
+        return usuario;
+    }
+
+    public Optional<Usuario> findByEmail(String email) {
+        return usuarioRepository.findByEmail(email);
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/UsuarioService.java
@@ -38,11 +38,10 @@ public class UsuarioService {
 
     public Usuario authenticate(String email, String rawPassword) {
         Usuario usuario = usuarioRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("Email ou senha inválidos"));
+                .orElseThrow(() -> new AuthenticationException("Email ou senha inválidos"));
 
         if (!passwordEncoder.matches(rawPassword, usuario.getPassword())) {
             throw new AuthenticationException("Email ou senha inválidos");
-
         }
 
         return usuario;

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/Role.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/Role.java
@@ -1,0 +1,7 @@
+package br.com.justina.domain.model;
+
+public enum Role {
+    ADMIN,
+    USER,
+    TRAINEE
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
@@ -1,0 +1,67 @@
+package br.com.justina.domain.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tb_sessoes_simulacao")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SessaoSimulacao {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    @NotNull(message = "Toda sessão deve pertencer a um usuário.")
+    private Usuario usuario;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime dataInicio;
+
+    private LocalDateTime dataFim;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusSessao status;
+
+    private Double pontuacaoGeral;
+    private Integer totalErros;
+    private Long tempoTotalSegundos;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        if (this.dataInicio == null) {
+            this.dataInicio = LocalDateTime.now();
+        }
+        // Toda sessão nova nasce em andamento
+        if (this.status == null) {
+            this.status = StatusSessao.EM_ANDAMENTO;
+        }
+    }
+
+    public boolean isFinalizada() {
+        return StatusSessao.FINALIZADA.equals(this.status);
+    }
+
+    public boolean isEmAndamento() {
+        return StatusSessao.EM_ANDAMENTO.equals(this.status);
+    }
+
+    public double getPercentualAcertos() {
+        if (totalErros == null || totalErros == 0) return 100.0;
+        return Math.max(0, 100.0 - (totalErros * 5));
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/StatusSessao.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/StatusSessao.java
@@ -1,0 +1,7 @@
+package br.com.justina.domain.model;
+
+public enum StatusSessao {
+    EM_ANDAMENTO,
+    FINALIZADA,
+    CANCELADA
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/Usuario.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/Usuario.java
@@ -1,0 +1,58 @@
+package br.com.justina.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Data;
+
+
+@Entity
+@Table(name = "tb_usuarios")
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class Usuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotBlank(message = "O nome é obrigatório")
+    private String name;
+
+    @Email(message = "E-mail inválido")
+    @NotBlank(message = "O e-mail é obrigatório")
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @NotBlank(message = "A senha é obrigatória")
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String password;
+
+    private String crm;
+
+    @NotNull(message = "O papel do usuário é obrigatório")
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Usuario(String name, String email, String password, Role role) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/repository/SessaoSimulacaoRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/repository/SessaoSimulacaoRepository.java
@@ -1,0 +1,10 @@
+package br.com.justina.domain.repository;
+
+import br.com.justina.domain.model.SessaoSimulacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+import java.util.List;
+
+public interface SessaoSimulacaoRepository extends JpaRepository<SessaoSimulacao, UUID> {
+    List<SessaoSimulacao> findByUsuarioIdOrderByDataInicioDesc(UUID usuarioId);
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/repository/SessaoSimulacaoRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/repository/SessaoSimulacaoRepository.java
@@ -1,10 +1,13 @@
 package br.com.justina.domain.repository;
 
 import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import br.com.justina.domain.model.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 import java.util.List;
 
 public interface SessaoSimulacaoRepository extends JpaRepository<SessaoSimulacao, UUID> {
+    boolean existsByUsuarioAndStatus(Usuario usuario, StatusSessao status);
     List<SessaoSimulacao> findByUsuarioIdOrderByDataInicioDesc(UUID usuarioId);
 }

--- a/backend_telemetry/src/main/java/br/com/justina/domain/repository/UsuarioRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/repository/UsuarioRepository.java
@@ -1,0 +1,14 @@
+package br.com.justina.domain.repository;
+
+import br.com.justina.domain.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
+    boolean existsByEmail(String email);
+    Optional<Usuario> findByEmail(String email);
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package br.com.justina.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // Desabilita CSRF para testar a API
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // Libera todos os endpoints por enquanto
+                );
+
+        return http.build();
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
@@ -20,11 +20,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // Desabilita CSRF para testar a API
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.disable())
+                )
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // Libera todos os endpoints por enquanto
+                        .anyRequest().permitAll()
                 );
 
         return http.build();
     }
+
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
@@ -13,6 +13,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -29,14 +35,29 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                // CORS - essencial para o Front
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/auth/**", "/h2-console/**", "/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .build();
+    }
+
+    // 2. Define as regras de quem pode acessar o CORS
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/config/SecurityConfig.java
@@ -1,16 +1,25 @@
 package br.com.justina.infrastructure.config;
 
+import br.com.justina.infrastructure.security.AuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AuthFilter authFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -18,17 +27,16 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers
-                        .frameOptions(frame -> frame.disable())
-                )
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
-
-        return http.build();
+                        .requestMatchers("/auth/**", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .build();
     }
-
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/LoginRequest.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/LoginRequest.java
@@ -1,9 +1,0 @@
-package br.com.justina.infrastructure.controller;
-
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-
-public record LoginRequest(
-        @NotBlank(message = "E-mail obrigatório") @Email String email,
-        @NotBlank(message = "Senha obrigatória") String password
-) {}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/LoginRequest.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/LoginRequest.java
@@ -1,0 +1,9 @@
+package br.com.justina.infrastructure.controller;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "E-mail obrigatório") @Email String email,
+        @NotBlank(message = "Senha obrigatória") String password
+) {}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/SessaoController.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/SessaoController.java
@@ -1,0 +1,32 @@
+package br.com.justina.infrastructure.controllers;
+
+import br.com.justina.application.dto.SessaoResponse;
+import br.com.justina.application.usecases.AbrirSessaoUseCase;
+import br.com.justina.application.usecases.FinalizarSessaoUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/sessoes")
+@RequiredArgsConstructor
+public class SessaoController {
+
+    private final AbrirSessaoUseCase abrirSessaoUseCase;
+
+    @PostMapping("/iniciar")
+    public ResponseEntity<SessaoResponse> iniciarSessao() {
+        SessaoResponse response = abrirSessaoUseCase.executar();
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    private final FinalizarSessaoUseCase finalizarSessaoUseCase;
+
+    @PutMapping("/{id}/finalizar")
+    public ResponseEntity<SessaoResponse> finalizarSessao(@PathVariable UUID id) {
+        SessaoResponse response = finalizarSessaoUseCase.executar(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
@@ -1,0 +1,30 @@
+package br.com.justina.infrastructure.controller;
+
+import br.com.justina.application.usecases.UsuarioService;
+import br.com.justina.domain.model.Usuario;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class UsuarioController {
+
+    private final UsuarioService usuarioService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Usuario> register(@RequestBody @Valid Usuario usuario) {
+        // chama método em inglês do Service
+        Usuario saved = usuarioService.register(usuario);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody @Valid LoginRequest request) {
+        Usuario usuario = usuarioService.authenticate(request.email(), request.password());
+        return ResponseEntity.ok("Login realizado com sucesso para: " + usuario.getName());
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
@@ -1,5 +1,6 @@
 package br.com.justina.infrastructure.controller;
 
+import br.com.justina.application.dto.LoginResponse;
 import br.com.justina.application.dto.RegisterRequest;
 import br.com.justina.application.usecases.UsuarioService;
 import br.com.justina.domain.model.Usuario;
@@ -27,8 +28,12 @@ public class UsuarioController {
 
 
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody @Valid LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         Usuario usuario = usuarioService.authenticate(request.email(), request.password());
-        return ResponseEntity.ok("Login realizado com sucesso para: " + usuario.getName());
+        return ResponseEntity.ok(new LoginResponse(
+                usuario.getName(),
+                usuario.getEmail(),
+                usuario.getRole().name()
+        ));
     }
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
@@ -1,5 +1,6 @@
 package br.com.justina.infrastructure.controller;
 
+import br.com.justina.application.dto.RegisterRequest;
 import br.com.justina.application.usecases.UsuarioService;
 import br.com.justina.domain.model.Usuario;
 import jakarta.validation.Valid;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import br.com.justina.application.dto.LoginRequest;
 
 @RestController
 @RequestMapping("/auth")
@@ -16,11 +18,13 @@ public class UsuarioController {
     private final UsuarioService usuarioService;
 
     @PostMapping("/register")
-    public ResponseEntity<Usuario> register(@RequestBody @Valid Usuario usuario) {
-        // chama método em inglês do Service
-        Usuario saved = usuarioService.register(usuario);
-        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    public ResponseEntity<String> register(@RequestBody @Valid RegisterRequest request) {
+
+        usuarioService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body("Usuário registrado com sucesso!");
     }
+
 
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequest request) {

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/controllers/UsuarioController.java
@@ -1,5 +1,6 @@
 package br.com.justina.infrastructure.controller;
 
+import br.com.justina.application.dto.LoginRequest;
 import br.com.justina.application.dto.LoginResponse;
 import br.com.justina.application.dto.RegisterRequest;
 import br.com.justina.application.usecases.UsuarioService;
@@ -9,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import br.com.justina.application.dto.LoginRequest;
 
 @RestController
 @RequestMapping("/auth")
@@ -20,17 +20,17 @@ public class UsuarioController {
 
     @PostMapping("/register")
     public ResponseEntity<String> register(@RequestBody @Valid RegisterRequest request) {
-
         usuarioService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body("Usuário registrado com sucesso!");
     }
 
-
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         Usuario usuario = usuarioService.authenticate(request.email(), request.password());
+
         return ResponseEntity.ok(new LoginResponse(
+                "MEU_TOKEN_DE_TESTE",
                 usuario.getName(),
                 usuario.getEmail(),
                 usuario.getRole().name()

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/AuthenticationException.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/AuthenticationException.java
@@ -1,0 +1,7 @@
+package br.com.justina.infrastructure.exception;
+
+public class AuthenticationException extends RuntimeException {
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/GlobalExceptionHandler.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/GlobalExceptionHandler.java
@@ -15,6 +15,11 @@ public class GlobalExceptionHandler {
                 .body(ex.getMessage());
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<String> handleRuntimeException(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/GlobalExceptionHandler.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package br.com.justina.infrastructure.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<String> handleAuthenticationException(AuthenticationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ex.getMessage());
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/security/AuthFilter.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/security/AuthFilter.java
@@ -33,7 +33,9 @@ public class AuthFilter extends OncePerRequestFilter {
 
         if ("MEU_TOKEN_DE_TESTE".equals(token)) {
             UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                    "UsuarioTeste", null, Collections.emptyList());
+                    "justina@teste.com",
+                    null,
+                    Collections.emptyList());
             SecurityContextHolder.getContext().setAuthentication(auth);
         } else {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/security/AuthFilter.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/security/AuthFilter.java
@@ -1,0 +1,53 @@
+package br.com.justina.infrastructure.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Token ausente\"}");
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if ("MEU_TOKEN_DE_TESTE".equals(token)) {
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                    "UsuarioTeste", null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Token inválido\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/auth/") || path.startsWith("/h2-console");
+    }
+}

--- a/backend_telemetry/src/main/resources/application.properties
+++ b/backend_telemetry/src/main/resources/application.properties
@@ -14,3 +14,8 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
+
+spring.h2.console.settings.web-allow-others=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.open-in-view=false

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
@@ -1,0 +1,50 @@
+package br.com.justina.domain.repository;
+
+import br.com.justina.domain.model.Role;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import br.com.justina.domain.model.Usuario;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest // Configura o ambiente leve de banco de dados para teste
+@ActiveProfiles("test")
+class SessaoSimulacaoRepositoryTest {
+
+    @Autowired
+    private SessaoSimulacaoRepository sessaoRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Test
+    @DisplayName("Deve persistir uma sessão e validar os valores automáticos")
+    void deveSalvarSessaoEValidarCampos() {
+        // 1. Criar um usuário (precisamos de um dono para a sessão)
+        Usuario medico = new Usuario();
+        medico.setName("Dr. Justina");
+        medico.setEmail("justina@hospital.com");
+        medico.setPassword("hash_da_senha");
+        medico.setRole(Role.ADMIN);
+        usuarioRepository.save(medico);
+
+        // 2. Criar a sessão
+        SessaoSimulacao sessao = SessaoSimulacao.builder()
+                .usuario(medico)
+                .build();
+
+        // 3. Salvar
+        SessaoSimulacao salva = sessaoRepository.save(sessao);
+
+        // 4. Verificar se funcionou
+        assertThat(salva.getId()).isNotNull(); // Gerou UUID?
+        assertThat(salva.getStatus()).isEqualTo(StatusSessao.EM_ANDAMENTO); // PrePersist funcionou?
+        assertThat(salva.getDataInicio()).isNotNull(); // Data de início foi setada?
+        assertThat(salva.getUsuario().getEmail()).isEqualTo("justina@hospital.com"); // Relacionamento OK?
+    }
+}

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest // Configura o ambiente leve de banco de dados para teste
+@DataJpaTest
 @ActiveProfiles("test")
 class SessaoSimulacaoRepositoryTest {
 
@@ -25,7 +25,7 @@ class SessaoSimulacaoRepositoryTest {
     @Test
     @DisplayName("Deve persistir uma sessão e validar os valores automáticos")
     void deveSalvarSessaoEValidarCampos() {
-        // 1. Criar um usuário (precisamos de um dono para a sessão)
+        // 1. Criar um usuário
         Usuario medico = new Usuario();
         medico.setName("Dr. Justina");
         medico.setEmail("justina@hospital.com");
@@ -42,9 +42,9 @@ class SessaoSimulacaoRepositoryTest {
         SessaoSimulacao salva = sessaoRepository.save(sessao);
 
         // 4. Verificar se funcionou
-        assertThat(salva.getId()).isNotNull(); // Gerou UUID?
-        assertThat(salva.getStatus()).isEqualTo(StatusSessao.EM_ANDAMENTO); // PrePersist funcionou?
-        assertThat(salva.getDataInicio()).isNotNull(); // Data de início foi setada?
-        assertThat(salva.getUsuario().getEmail()).isEqualTo("justina@hospital.com"); // Relacionamento OK?
+        assertThat(salva.getId()).isNotNull();
+        assertThat(salva.getStatus()).isEqualTo(StatusSessao.EM_ANDAMENTO);
+        assertThat(salva.getDataInicio()).isNotNull();
+        assertThat(salva.getUsuario().getEmail()).isEqualTo("justina@hospital.com");
     }
 }

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/SessaoSimulacaoRepositoryTest.java
@@ -25,7 +25,7 @@ class SessaoSimulacaoRepositoryTest {
     @Test
     @DisplayName("Deve persistir uma sessão e validar os valores automáticos")
     void deveSalvarSessaoEValidarCampos() {
-        // 1. Criar um usuário
+        // 1. Criar um usuário teste
         Usuario medico = new Usuario();
         medico.setName("Dr. Justina");
         medico.setEmail("justina@hospital.com");

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@ActiveProfiles("dev") // Isso força o uso do H2 que configuramos
+@ActiveProfiles("dev")
 class UsuarioRepositoryTest {
 
     @Autowired
@@ -30,10 +30,8 @@ class UsuarioRepositoryTest {
                 Role.ADMIN
         );
 
-        // 2. Act (Executar a ação)
         Usuario salvo = repository.save(novoUsuario);
 
-        // 3. Assert (Verificar se deu certo)
         assertNotNull(salvo.getId());
 
         Optional<Usuario> buscado = repository.findByEmail("house@diagnostico.com");

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
@@ -22,7 +22,7 @@ class UsuarioRepositoryTest {
     @Test
     @DisplayName("Deveria salvar um novo usuário e buscá-lo por e-mail no H2")
     void deveriaSalvarEBuscarUsuario() {
-        // 1. Arrange (Preparar os dados)
+        // 1. Preparar os dados
         Usuario novoUsuario = new Usuario(
                 "Dr. Gregory House",
                 "house@diagnostico.com",

--- a/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/domain/repository/UsuarioRepositoryTest.java
@@ -1,0 +1,44 @@
+package br.com.justina.domain.repository; // Ajuste o package se necessário
+
+import br.com.justina.domain.model.Usuario;
+import br.com.justina.domain.model.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("dev") // Isso força o uso do H2 que configuramos
+class UsuarioRepositoryTest {
+
+    @Autowired
+    private UsuarioRepository repository;
+
+    @Test
+    @DisplayName("Deveria salvar um novo usuário e buscá-lo por e-mail no H2")
+    void deveriaSalvarEBuscarUsuario() {
+        // 1. Arrange (Preparar os dados)
+        Usuario novoUsuario = new Usuario(
+                "Dr. Gregory House",
+                "house@diagnostico.com",
+                "vicioemvicodin",
+                Role.ADMIN
+        );
+
+        // 2. Act (Executar a ação)
+        Usuario salvo = repository.save(novoUsuario);
+
+        // 3. Assert (Verificar se deu certo)
+        assertNotNull(salvo.getId());
+
+        Optional<Usuario> buscado = repository.findByEmail("house@diagnostico.com");
+        assertTrue(buscado.isPresent());
+        assertEquals("Dr. Gregory House", buscado.get().getName());
+        assertNotNull(buscado.get().getCreatedAt());
+    }
+}


### PR DESCRIPTION
# Autenticação e Sessões de Simulação

## Issues relacionadas
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17

## O que foi feito
- Criada entidade Usuario
- Implementado endpoint POST /auth/register
- Implementado endpoint POST /auth/login
- Implementado AuthFilter (middleware de autenticação)
- Criada entidade SessaoSimulacao
- Implementado endpoint para iniciar sessão
- Implementado endpoint para finalizar sessão
- Regra de bloqueio para múltiplas sessões ativas
- Cálculo automático de tempoTotalSegundos
- Testes de integração do repositório

## Observações
- Autenticação usando token fixo (MEU_TOKEN_DE_TESTE) para ambiente de testes
- Preparado para futura implementação com JWT
- Banco H2 em memória para desenvolvimento
