### PR TITLE
feat:_Implement_FinalizarCirurgiaUseCase_Task_7

### DIFF
--- a/backend_telemetry/src/main/java/br/com/justina/application/ports/output/IAiClientPort.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/ports/output/IAiClientPort.java
@@ -3,7 +3,9 @@ package br.com.justina.application.ports.output;
 import br.com.justina.domain.model.FeedbackIA;
 import br.com.justina.domain.model.Telemetria;
 import java.util.List;
+import java.util.UUID;
 
 public interface IAiClientPort {
     FeedbackIA analisarMovimentos(List<Telemetria> movimentos);
+    void solicitarRelatorioFinal(UUID sessaoId); // Novo método para trigger assíncrono
 }

--- a/backend_telemetry/src/main/java/br/com/justina/application/ports/output/ITelemetriaRepositoryPort.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/ports/output/ITelemetriaRepositoryPort.java
@@ -1,11 +1,18 @@
 package br.com.justina.application.ports.output;
 
 import br.com.justina.domain.model.Telemetria;
+import br.com.justina.domain.model.SessaoSimulacao;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface ITelemetriaRepositoryPort {
     
-    // Contrato: ao implementar essa interface é obrigatório salvar uma lista
+    // Telemetria
     void salvarTudo(List<Telemetria> movimentos);
+
+    // Sessão
+    Optional<SessaoSimulacao> buscarSessaoPorId(UUID id);
+    SessaoSimulacao salvarSessao(SessaoSimulacao sessao);
 
 }

--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/FinalizarCirurgiaUseCase.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/FinalizarCirurgiaUseCase.java
@@ -1,0 +1,63 @@
+package br.com.justina.application.usecases;
+
+import br.com.justina.application.ports.output.IAiClientPort;
+import br.com.justina.application.ports.output.ITelemetriaRepositoryPort;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinalizarCirurgiaUseCase {
+
+    private final ITelemetriaRepositoryPort repository;
+    private final IAiClientPort aiClient;
+
+    @Transactional
+    public SessaoSimulacao executar(UUID sessaoId) {
+        log.info("Iniciando finalização da cirurgia/sessão: {}", sessaoId);
+
+        // 1. Buscar Sessão
+        SessaoSimulacao sessao = repository.buscarSessaoPorId(sessaoId)
+                .orElseThrow(() -> new IllegalArgumentException("Sessão não encontrada: " + sessaoId));
+
+        // 2. Validar Status
+        if (sessao.isFinalizada()) {
+            log.warn("Tentativa de finalizar sessão já encerrada: {}", sessaoId);
+            return sessao; // Idempotência: se já finalizou, retorna como está
+        }
+
+        // 3. Atualizar Dados de Finalização
+        LocalDateTime agora = LocalDateTime.now();
+        sessao.setDataFim(agora);
+        sessao.setStatus(StatusSessao.FINALIZADA);
+
+        // Calcular tempo total em segundos
+        if (sessao.getDataInicio() != null) {
+            long segundos = Duration.between(sessao.getDataInicio(), agora).getSeconds();
+            sessao.setTempoTotalSegundos(segundos);
+        }
+
+        // 4. Salvar (Persistência)
+        SessaoSimulacao sessaoSalva = repository.salvarSessao(sessao);
+        log.info("Sessão {} finalizada com sucesso. Tempo total: {}s", sessaoId, sessao.getTempoTotalSegundos());
+
+        // 5. Acionar IA (Trigger Assíncrono)
+        try {
+            aiClient.solicitarRelatorioFinal(sessaoId);
+        } catch (Exception e) {
+            log.error("Erro ao solicitar relatório final para IA (Sessão {}): {}", sessaoId, e.getMessage());
+            // Não relança exceção para não rollbackar a finalização da sessão no banco
+        }
+
+        return sessaoSalva;
+    }
+}

--- a/backend_telemetry/src/test/java/br/com/justina/application/usecases/FinalizarCirurgiaUseCaseTest.java
+++ b/backend_telemetry/src/test/java/br/com/justina/application/usecases/FinalizarCirurgiaUseCaseTest.java
@@ -1,0 +1,89 @@
+package br.com.justina.application.usecases;
+
+import br.com.justina.application.ports.output.IAiClientPort;
+import br.com.justina.application.ports.output.ITelemetriaRepositoryPort;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FinalizarCirurgiaUseCaseTest {
+
+    @Mock
+    private ITelemetriaRepositoryPort repository;
+
+    @Mock
+    private IAiClientPort aiClient;
+
+    @InjectMocks
+    private FinalizarCirurgiaUseCase useCase;
+
+    private SessaoSimulacao sessao;
+    private UUID sessaoId;
+
+    @BeforeEach
+    void setUp() {
+        sessaoId = UUID.randomUUID();
+        sessao = SessaoSimulacao.builder()
+                .id(sessaoId)
+                .status(StatusSessao.EM_ANDAMENTO)
+                .dataInicio(LocalDateTime.now().minusMinutes(10)) // Começou há 10 min
+                .build();
+    }
+
+    @Test
+    void deveFinalizarSessaoComSucesso() {
+        when(repository.buscarSessaoPorId(sessaoId)).thenReturn(Optional.of(sessao));
+        when(repository.salvarSessao(any(SessaoSimulacao.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SessaoSimulacao resultado = useCase.executar(sessaoId);
+
+        assertEquals(StatusSessao.FINALIZADA, resultado.getStatus());
+        assertNotNull(resultado.getDataFim());
+        assertNotNull(resultado.getTempoTotalSegundos());
+        assertTrue(resultado.getTempoTotalSegundos() >= 600); // Pelo menos 10 min (600s)
+
+        verify(repository).salvarSessao(sessao);
+        verify(aiClient).solicitarRelatorioFinal(sessaoId);
+    }
+
+    @Test
+    void deveLancarExcecaoSeSessaoNaoExiste() {
+        when(repository.buscarSessaoPorId(sessaoId)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.executar(sessaoId));
+        
+        verify(repository, never()).salvarSessao(any());
+        verify(aiClient, never()).solicitarRelatorioFinal(any());
+    }
+
+    @Test
+    void naoDeveFinalizarNovamenteSeJaEstiverFinalizada() {
+        sessao.setStatus(StatusSessao.FINALIZADA);
+        sessao.setDataFim(LocalDateTime.now().minusMinutes(1));
+        
+        when(repository.buscarSessaoPorId(sessaoId)).thenReturn(Optional.of(sessao));
+
+        SessaoSimulacao resultado = useCase.executar(sessaoId);
+
+        assertEquals(StatusSessao.FINALIZADA, resultado.getStatus());
+        // Data fim não deve ter sido alterada para "agora", deve manter a antiga
+        assertEquals(sessao.getDataFim(), resultado.getDataFim());
+
+        verify(repository, never()).salvarSessao(any()); // Não salva se não mudou
+        verify(aiClient, never()).solicitarRelatorioFinal(any()); // Não chama IA de novo
+    }
+}


### PR DESCRIPTION
### Resumo da Implementação - FinalizarCirurgiaUseCase

Implementação concluída com as seguintes entregas:

1. **Entidades e Interfaces:**
   - Atualizei `ITelemetriaRepositoryPort` e `IAiClientPort` para suportar a busca/salvamento de sessões e o trigger assíncrono da IA.

2. **Lógica de Negócio (`FinalizarCirurgiaUseCase`):**
   - Busca a sessão pelo ID.
   - Valida se já não está encerrada.
   - Calcula o tempo total da cirurgia.
   - Atualiza status para `FINALIZADA`.
   - Dispara solicitação de relatório para a IA (sem bloquear se falhar).

3. **Testes (`FinalizarCirurgiaUseCaseTest`):**
   - Criei testes unitários cobrindo o fluxo de sucesso, validação de sessão inexistente e idempotência (não finalizar duas vezes).