### PR TITLE
Implementação Persistência JPA (PostgreSQL) e Resolução de Conflitos com Dev

### DIFF
--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
@@ -1,0 +1,21 @@
+package br.com.justina.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "tb_sessoes_simulacao")
+public class SessaoSimulacao {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private LocalDateTime dataInicio;
+    
+    // Resultados da IA
+    private String statusIa;   
+    private Double precisaoIa;
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
@@ -1,16 +1,6 @@
 package br.com.justina.domain.model;
 
 import jakarta.persistence.*;
-<<<<<<< HEAD
-import lombok.Data;
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-@Data
-@Entity
-@Table(name = "tb_sessoes_simulacao")
-public class SessaoSimulacao {
-=======
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -25,18 +15,11 @@ import java.util.UUID;
 @Builder
 public class SessaoSimulacao {
 
->>>>>>> origin/dev
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-<<<<<<< HEAD
-    private LocalDateTime dataInicio;
-    
-    // Resultados da IA
-    private String statusIa;   
-    private Double precisaoIa;
-=======
+    // --- (Vínculo com Usuário) ---
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "usuario_id", nullable = false)
     @NotNull(message = "Toda sessão deve pertencer a um usuário.")
@@ -51,25 +34,32 @@ public class SessaoSimulacao {
     @Column(nullable = false)
     private StatusSessao status;
 
+    // --- (Métricas Gerais) ---
     private Double pontuacaoGeral;
     private Integer totalErros;
     private Long tempoTotalSegundos;
 
+    // --- (Resultados da IA) ---
+    private String statusIa;   
+    private Double precisaoIa;
+
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    // --- LÓGICA AUTOMÁTICA (Ciclo de Vida) ---
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         if (this.dataInicio == null) {
             this.dataInicio = LocalDateTime.now();
         }
-        // Toda sessão nova nasce em andamento
+        
         if (this.status == null) {
             this.status = StatusSessao.EM_ANDAMENTO;
         }
     }
 
+    
     public boolean isFinalizada() {
         return StatusSessao.FINALIZADA.equals(this.status);
     }
@@ -82,5 +72,4 @@ public class SessaoSimulacao {
         if (totalErros == null || totalErros == 0) return 100.0;
         return Math.max(0, 100.0 - (totalErros * 5));
     }
->>>>>>> origin/dev
 }

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/Telemetria.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/Telemetria.java
@@ -1,18 +1,28 @@
 package br.com.justina.domain.model;
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.util.UUID;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Entity
+@Table(name = "tb_telemetrias")
 public class Telemetria {
-    
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
     private Double eixoX;
     private Double eixoY;
-    private Double eixoZ;    
-    private String tempo; 
-    
-    
+    private Double eixoZ;
+    private String tempo;
+
+    // Vínculo com a sessão
+    @ManyToOne
+    @JoinColumn(name = "sessao_id")
+    private SessaoSimulacao sessao;
 }

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/Telemetria.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/Telemetria.java
@@ -12,25 +12,31 @@ import java.util.UUID;
 @Entity
 @Table(name = "tb_telemetrias")
 public class Telemetria {
+    
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    // --- Coordenadas (Mantido) ---
+    // --- Coordenadas ---
     private Double eixoX;
     private Double eixoY;
     private Double eixoZ;
 
-    // --- Novidades da Equipe (Adicionado) ---
+    
     private Double rotacao; 
     private String eventId;
 
-    // --- Tempo (Adotamos a versão da equipe: LocalDateTime) ---
+    // --- Tempo ---
     private LocalDateTime timestamp;
 
-    // --- Relacionamento (Mantendo JPA) ---
-    // Foi sugerida 'String sessionId', mas no objeto real é necessário para as chaves estrangeiras.
+    // --- Relacionamento JPA (O que vale para o Banco) ---
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sessao_id")
     private SessaoSimulacao sessao;
+
+    
+    // Adicionei o sessionId para o TelemetryEngine funcionar, 
+    // mas marquei como @Transient para não salvar no banco (o banco usa o 'sessao' acima)
+    @Transient
+    private String sessionId;
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/JpaSessaoRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/JpaSessaoRepository.java
@@ -1,0 +1,9 @@
+package br.com.justina.infrastructure.persistence;
+
+import br.com.justina.domain.model.SessaoSimulacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface JpaSessaoRepository extends JpaRepository<SessaoSimulacao, UUID> {}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/JpaTelemetriaRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/JpaTelemetriaRepository.java
@@ -1,0 +1,9 @@
+package br.com.justina.infrastructure.persistence;
+
+import br.com.justina.domain.model.Telemetria;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface JpaTelemetriaRepository extends JpaRepository<Telemetria, UUID> {}

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/TelemetriaDatabaseAdapter.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/TelemetriaDatabaseAdapter.java
@@ -2,41 +2,61 @@ package br.com.justina.infrastructure.persistence;
 
 import br.com.justina.application.ports.output.ITelemetriaRepositoryPort;
 import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.StatusSessao;
 import br.com.justina.domain.model.Telemetria;
+import br.com.justina.domain.model.Usuario;
+// import br.com.justina.domain.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
+import java.util.Optional;
 
 @Component
-@Primary // Importante: Substitui o banco de memória
+@Primary
 @RequiredArgsConstructor
 public class TelemetriaDatabaseAdapter implements ITelemetriaRepositoryPort {
 
     private final JpaTelemetriaRepository telemetriaRepo;
     private final JpaSessaoRepository sessaoRepo;
+    // private final UsuarioRepository usuarioRepo;
 
     @Override
     public void salvarTudo(List<Telemetria> movimentos) {
         if (movimentos.isEmpty()) return;
 
-        // 1. Cria a Sessão
+        // Usuario usuarioFake = new Usuario(); 
+        
         SessaoSimulacao sessao = new SessaoSimulacao();
+        // sessao.setUsuario(usuarioFake); 
         sessao.setDataInicio(LocalDateTime.now());
+        sessao.setStatus(StatusSessao.EM_ANDAMENTO);
         sessao.setStatusIa("PROCESSADO"); 
         
-        sessao = sessaoRepo.save(sessao);
+        // sessao = sessaoRepo.save(sessao); 
 
-        // 2. Vincula movimentos à sessão
         for (Telemetria t : movimentos) {
             t.setSessao(sessao);
+            if (t.getTimestamp() == null) {
+                t.setTimestamp(LocalDateTime.now());
+            }
         }
-
-        // 3. Salva movimentos
-        telemetriaRepo.saveAll(movimentos);
         
-        System.out.println(" DB: Sessão " + sessao.getId() + " salva com sucesso!");
+        // telemetriaRepo.saveAll(movimentos);
+        System.out.println("COMPILAÇÃO: Dados recebidos (Persistência pausada para ajuste de Usuário)");
+    }
+
+    @Override
+    public SessaoSimulacao salvarSessao(SessaoSimulacao sessao) {
+        return sessaoRepo.save(sessao);
+    }
+
+    
+    @Override
+    public Optional<SessaoSimulacao> buscarSessaoPorId(UUID id) {
+        return sessaoRepo.findById(id);
     }
 }

--- a/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/TelemetriaDatabaseAdapter.java
+++ b/backend_telemetry/src/main/java/br/com/justina/infrastructure/persistence/TelemetriaDatabaseAdapter.java
@@ -1,0 +1,42 @@
+package br.com.justina.infrastructure.persistence;
+
+import br.com.justina.application.ports.output.ITelemetriaRepositoryPort;
+import br.com.justina.domain.model.SessaoSimulacao;
+import br.com.justina.domain.model.Telemetria;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@Primary // Importante: Substitui o banco de memória
+@RequiredArgsConstructor
+public class TelemetriaDatabaseAdapter implements ITelemetriaRepositoryPort {
+
+    private final JpaTelemetriaRepository telemetriaRepo;
+    private final JpaSessaoRepository sessaoRepo;
+
+    @Override
+    public void salvarTudo(List<Telemetria> movimentos) {
+        if (movimentos.isEmpty()) return;
+
+        // 1. Cria a Sessão
+        SessaoSimulacao sessao = new SessaoSimulacao();
+        sessao.setDataInicio(LocalDateTime.now());
+        sessao.setStatusIa("PROCESSADO"); 
+        
+        sessao = sessaoRepo.save(sessao);
+
+        // 2. Vincula movimentos à sessão
+        for (Telemetria t : movimentos) {
+            t.setSessao(sessao);
+        }
+
+        // 3. Salva movimentos
+        telemetriaRepo.saveAll(movimentos);
+        
+        System.out.println(" DB: Sessão " + sessao.getId() + " salva com sucesso!");
+    }
+}

--- a/backend_telemetry/src/main/resources/application.properties
+++ b/backend_telemetry/src/main/resources/application.properties
@@ -1,16 +1,13 @@
-
 spring.application.name=JustinaBackend
-
-# Porta do Java
 server.port=8081
-
-# Configuração do Serviço Python (AI Service)
 app.ai-service.url=http://localhost:5000
 
-# Configuração básica de banco em memória (H2) para teste rápido
-spring.datasource.url=jdbc:h2:mem:justinadb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.h2.console.enabled=true
+# --- BANCO DE DADOS (Postgres Docker) ---
+spring.datasource.url=jdbc:postgresql://localhost:5432/justina_db
+spring.datasource.username=user_justina
+spring.datasource.password=password_justina
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA (Cria as tabelas automaticamente)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
## 🚀 Resumo da Entrega
Este PR implementa a camada de infraestrutura para persistência de dados utilizando **Spring Data JPA** e **PostgreSQL** (via Docker), substituindo a implementação em memória.

Além disso, foi realizado o **Merge com a branch `dev`**, integrando as minhas alterações com as novas funcionalidades da equipe (Autenticação, TelemetryEngine e Entidade Usuário).

### 🛠️ O que foi feito:
- **Infraestrutura:**
  - Configuração do `application.properties` para PostgreSQL.
  - Implementação de `JpaTelemetriaRepository` e `JpaSessaoRepository`.
  - Criação do `TelemetriaDatabaseAdapter` implementando a interface `ITelemetriaRepositoryPort`.
- **Domínio (Entities):**
  - Mapeamento ORM (`@Entity`) nas classes `Telemetria` e `SessaoSimulacao`.
  - Unificação dos campos de IA (meus) com os campos de Negócio/User (da equipe).
- **Resolução de Conflitos (Merge):**
  - Integração manual das classes conflitantes mantendo a estrutura do Lombok/Builder da equipe.
  - Implementação dos novos métodos exigidos na interface (`salvarSessao`, `buscarSessaoPorId`).

### ⚠️ Nota Técnica Importante (WIP)
Para garantir o **Build Success** e a integridade do Merge, a lógica de persistência dentro do `TelemetriaDatabaseAdapter` foi temporariamente simplificada (trechos comentados).
- **Motivo:** A entidade `Usuario` agora é obrigatória na `Sessao`, e precisamos alinhar a criação do usuário padrão com o padrão Builder implementado pela equipe.
- **Próximo Passo:** Ajustar a injeção do `UsuarioRepository` para descomentar a persistência.

### 🧪 Estado Atual
- ✅ Compilação (Maven Build Success).
- ✅ Conflitos de Git resolvidos.
- ✅ Docker Compose configurado.