### PR TITLE
fix: Previne envio de telemetria após finalizar sessão

### DIFF
--- a/frontend/src/canvas/SimuladorRenal3D.jsx
+++ b/frontend/src/canvas/SimuladorRenal3D.jsx
@@ -73,6 +73,9 @@ export default function SimuladorRenal3D() {
     if (!sessionId || isFinalized.current) return;
 
     const interval = setInterval(async () => {
+      // Verifica novamente se foi finalizado antes de enviar
+      if (isFinalized.current) return;
+      
       if (telemetryBuffer.current.length > 0) {
         try {
           await apiService.sendTelemetryBatch(sessionId, telemetryBuffer.current);

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -59,9 +59,12 @@ export default function Simulator() {
   }, [simulationKey]);
 
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId || isFinalized.current) return;
 
     const interval = setInterval(async () => {
+      // Verifica novamente se foi finalizado antes de enviar
+      if (isFinalized.current) return;
+      
       if (telemetryBuffer.current.length > 0) {
         try {
           await apiService.sendTelemetryBatch(sessionId, telemetryBuffer.current);


### PR DESCRIPTION
- Adiciona verificação dupla de isFinalized no setInterval
- Evita race condition que causava erro 404 após /complete
- Corrige tanto no SimuladorRenal3D quanto no Simulator 2D