### PR TITLE
feat: Adiciona Soft Delete em Treinamento e preserva lógica de Cirurgia

### DIFF
--- a/backend_telemetry/src/main/java/br/com/justina/application/usecases/RegistrarMovimentoUseCase.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/usecases/RegistrarMovimentoUseCase.java
@@ -7,7 +7,6 @@ import br.com.justina.domain.model.Cirurgia;
 import br.com.justina.domain.model.FeedbackIA;
 import br.com.justina.domain.model.SessaoSimulacao;
 import br.com.justina.domain.model.Telemetria;
-import br.com.justina.infrastructure.exception.RegraCirurgiaException;
 import br.com.justina.domain.repository.CirurgiaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,13 +30,16 @@ public class RegistrarMovimentoUseCase {
     public FeedbackIA executar(UUID usuarioId, List<Telemetria> movimentos) {
         log.info("Persistindo {} movimentos para usuário {} e solicitando análise IA", movimentos.size(), usuarioId);
 
+        // Verifica se há movimentos e se a sessão está presente (mesmo que transiente)
         if (!movimentos.isEmpty() && movimentos.get(0).getSessao() != null) {
             SessaoSimulacao sessao = movimentos.get(0).getSessao();
 
             // 1. Vincula a cirurgia ANTES de tentar salvar no banco!
+            // (Isso corrige o erro de 'transient value' que poderia acontecer)
             if (sessao.getCirurgia() == null) {
+                // Pega a primeira cirurgia disponível no banco como padrão (ou lance erro)
                 Cirurgia cirurgiaBase = cirurgiaRepository.findAll().stream().findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Nenhuma cirurgia cadastrada no sistema!"));
+                        .orElseThrow(() -> new IllegalStateException("Nenhuma cirurgia cadastrada no sistema! Cadastre uma cirurgia antes de simular."));
                 sessao.setCirurgia(cirurgiaBase);
             }
 
@@ -47,7 +49,7 @@ public class RegistrarMovimentoUseCase {
             }
         }
 
-        // 3. Pede feedback para a IA do Google Gemini
+        // 3. Pede feedback para a IA (Python)
         FeedbackIA feedback = aiClient.analisarMovimentos(movimentos);
 
         // 4. Se a IA detectou um erro crítico, penalizamos a sessão
@@ -58,14 +60,15 @@ public class RegistrarMovimentoUseCase {
             sessao.setTotalErros(erros + 1);
         }
 
-        // 5. Persiste tudo
+        // 5. Persiste tudo no banco
         repository.salvarTudo(usuarioId, movimentos);
 
+        // Loga o resultado
         if (!movimentos.isEmpty() && movimentos.get(0).getSessao() != null) {
             SessaoSimulacao sessao = movimentos.get(0).getSessao();
+            // Salva o estado atualizado da sessão (com erros computados)
             repository.salvarSessao(sessao);
-            log.info("Sessão {} salva com sucesso. Erros acumulados: {} | Pontuação: {}",
-                    sessao.getId(), sessao.getTotalErros(), sessao.getPontuacaoGeral());
+            log.info("Sessão {} processada. Erros acumulados: {}", sessao.getId(), sessao.getTotalErros());
         }
 
         return feedback;

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/SessaoSimulacao.java
@@ -24,10 +24,11 @@ public class SessaoSimulacao {
     @NotNull(message = "Toda sessão deve pertencer a um usuário.")
     private Usuario usuario;
 
+    
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "cirurgia_id", nullable = false)
     @NotNull(message = "Toda sessão deve estar vinculada a um procedimento cirúrgico.")
-    private Cirurgia cirurgia; // MANTIDO!
+    private Cirurgia cirurgia;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime dataInicio;
@@ -38,34 +39,27 @@ public class SessaoSimulacao {
     @Column(nullable = false)
     private StatusSessao status;
 
-    // --- (Métricas Gerais) ---
+    // Métricas Gerais
     private Double pontuacaoGeral;
     private Integer totalErros;
     private Long tempoTotalSegundos;
 
-    // --- (Resultados da IA) ---
+    // Resultados da IA
     private String statusIa;
     private Double precisaoIa;
-    
-    // --- NOVO CAMPO (Adicionado agora) ---
     private String relatorioUrl;
 
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    // --- LÓGICA AUTOMÁTICA (Ciclo de Vida) ---
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
-        if (this.dataInicio == null) {
-            this.dataInicio = LocalDateTime.now();
-        }
-
-        if (this.status == null) {
-            this.status = StatusSessao.EM_ANDAMENTO;
-        }
+        if (this.dataInicio == null) dataInicio = LocalDateTime.now();
+        if (this.status == null) status = StatusSessao.EM_ANDAMENTO;
     }
 
+    
     public boolean isFinalizada() {
         return StatusSessao.FINALIZADA.equals(this.status);
     }
@@ -74,6 +68,7 @@ public class SessaoSimulacao {
         return StatusSessao.EM_ANDAMENTO.equals(this.status);
     }
 
+    
     public double getPercentualAcertos() {
         if (totalErros == null || totalErros == 0)
             return 100.0;

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/common/BaseEntity.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/common/BaseEntity.java
@@ -1,0 +1,42 @@
+package br.com.justina.domain.model.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+public abstract class BaseEntity {
+    
+    @Column(name = "active", nullable = false)
+    private Boolean active = true;
+    
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+    
+    @Column(name = "deleted_by")
+    private String deletedBy;
+    
+    // Nome alterado para não conflitar com StatusSessao
+    @Column(name = "persistence_status", length = 20)
+    private String persistenceStatus = "enabled";
+    
+    @PrePersist
+    public void prePersistBase() {
+        if (active == null) active = true;
+        if (persistenceStatus == null) persistenceStatus = "enabled";
+    }
+    
+    public void softDelete(String deletedBy) {
+        this.active = false;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+        this.persistenceStatus = "deleted";
+    }
+    
+    public boolean isActive() {
+        return Boolean.TRUE.equals(active);
+    }
+}

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/training/Question.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/training/Question.java
@@ -1,7 +1,9 @@
 package br.com.justina.domain.model.training;
 
+import br.com.justina.domain.model.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
@@ -13,7 +15,9 @@ import java.util.UUID;
     @Index(name = "idx_questions_type", columnList = "type"),
     @Index(name = "idx_questions_media", columnList = "mediaUrl")
 })
-public class Question {
+@EqualsAndHashCode(callSuper = false)
+public class Question extends BaseEntity { // Herança OK
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -25,7 +29,6 @@ public class Question {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String text;
 
-    // JSONB mapeado como String para flexibilidade
     @Column(columnDefinition = "jsonb", nullable = false)
     private String options; 
 
@@ -42,7 +45,5 @@ public class Question {
     @UpdateTimestamp
     private LocalDateTime modifiedAt;
 
-    private Boolean active = true;
-    private String status = "enabled";
     private Integer version = 1;
 }

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/training/TrainingProgram.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/training/TrainingProgram.java
@@ -1,7 +1,9 @@
 package br.com.justina.domain.model.training;
 
+import br.com.justina.domain.model.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
@@ -10,7 +12,8 @@ import java.util.UUID;
 @Data
 @Entity
 @Table(name = "training_programs")
-public class TrainingProgram {
+@EqualsAndHashCode(callSuper = false)
+public class TrainingProgram extends BaseEntity { // Herança OK
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -37,10 +40,5 @@ public class TrainingProgram {
     @UpdateTimestamp
     private LocalDateTime modifiedAt;
 
-    private Boolean active = true;
-    private String status = "enabled";
     private Integer version = 1;
-    
-    // Vínculo com autor pode ser adicionado depois se Usuario existir
-    // private UUID authorId;
 }


### PR DESCRIPTION
## 🚀 Feature: Soft Delete e Módulo de Treinamento

### 📋 Resumo
Este PR implementa a estrutura de **Soft Delete** solicitada para as entidades de Treinamento (`TrainingProgram`, `Question`) e restaura a sincronia com a branch `dev`, preservando a lógica de `SessaoSimulacao` e `Cirurgia` implementada pela equipe.

### 🛠️ Alterações Realizadas

1.  **Infraestrutura de Entidades (`BaseEntity`):**
    *   Criação da classe abstrata `BaseEntity` para gerenciar auditoria e deleção lógica.
    *   **Ajuste Crítico:** O campo de controle foi renomeado para `persistenceStatus` para evitar conflitos com o Enum `status` existente em outras entidades.

2.  **Módulo de Treinamento:**
    *   As entidades `TrainingProgram` e `Question` agora estendem `BaseEntity`, habilitando o Soft Delete.

3.  **Preservação de Lógica (Merge):**
    *   A entidade `SessaoSimulacao` **NÃO** foi alterada para estender `BaseEntity`, garantindo que a lógica de `StatusSessao` e o vínculo com `Cirurgia` (implementados pela equipe) permaneçam intactos e funcionais.

### ✅ Checklist
- [x] Build Backend (`mvn clean install`) - Sucesso.
- [x] Soft Delete implementado sem quebrar entidades existentes.
- [x] Sincronizado com as últimas atualizações da `dev`.