### PR TITLE
refactor: Altera campo options de String para List<String> (JSONB Nativo)

### DIFF
--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/CreateQuestionRequest.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/CreateQuestionRequest.java
@@ -1,11 +1,12 @@
 package br.com.justina.application.dto;
 
 import br.com.justina.domain.model.training.QuestionType;
+import java.util.List;
 
 public record CreateQuestionRequest(
         QuestionType type,
         String text,
-        String options, // JSON string
+        List<String> options, // Lista de Strings
         Integer correctIndex,
         String hint,
         String topic,

--- a/backend_telemetry/src/main/java/br/com/justina/application/dto/QuestionResponse.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/dto/QuestionResponse.java
@@ -1,14 +1,14 @@
 package br.com.justina.application.dto;
 
 import br.com.justina.domain.model.training.Question;
-
+import java.util.List; 
 import java.util.UUID;
 
 public record QuestionResponse(
         UUID id,
         String type,
         String text,
-        String options,
+        List<String> options, 
         Integer correctIndex,
         String hint,
         String topic,
@@ -17,9 +17,9 @@ public record QuestionResponse(
     public QuestionResponse(Question q) {
         this(
                 q.getId(),
-                q.getType().name(),
+                q.getType().name(), // Converte o Enum para String
                 q.getText(),
-                q.getOptions(),
+                q.getOptions(),     
                 q.getCorrectIndex(),
                 q.getHint(),
                 q.getTopic(),

--- a/backend_telemetry/src/main/java/br/com/justina/application/services/QuestionService.java
+++ b/backend_telemetry/src/main/java/br/com/justina/application/services/QuestionService.java
@@ -2,7 +2,7 @@ package br.com.justina.application.services;
 
 import br.com.justina.application.dto.CreateQuestionRequest;
 import br.com.justina.domain.model.training.Question;
-import br.com.justina.domain.repository.QuestionRepository;
+import br.com.justina.domain.repository.training.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,11 +16,13 @@ public class QuestionService {
     private final QuestionRepository repository;
 
     public Question create(CreateQuestionRequest request) {
-
         Question question = new Question();
         question.setType(request.type());
         question.setText(request.text());
-        question.setOptions(request.options());
+        
+        // Agora isso funciona, pois request.options() retorna List<String>
+        question.setOptions(request.options()); 
+        
         question.setCorrectIndex(request.correctIndex());
         question.setHint(request.hint());
         question.setTopic(request.topic());

--- a/backend_telemetry/src/main/java/br/com/justina/domain/model/training/Question.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/model/training/Question.java
@@ -6,7 +6,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.JdbcTypeCode; 
+import org.hibernate.type.SqlTypes;           
+
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Data
@@ -16,7 +20,7 @@ import java.util.UUID;
     @Index(name = "idx_questions_media", columnList = "mediaUrl")
 })
 @EqualsAndHashCode(callSuper = false)
-public class Question extends BaseEntity { // Herança OK
+public class Question extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -29,8 +33,10 @@ public class Question extends BaseEntity { // Herança OK
     @Column(columnDefinition = "TEXT", nullable = false)
     private String text;
 
+    
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb", nullable = false)
-    private String options; 
+    private List<String> options; 
 
     @Column(name = "correct_index", nullable = false)
     private Integer correctIndex;

--- a/backend_telemetry/src/main/java/br/com/justina/domain/repository/training/QuestionRepository.java
+++ b/backend_telemetry/src/main/java/br/com/justina/domain/repository/training/QuestionRepository.java
@@ -1,9 +1,10 @@
-package br.com.justina.domain.repository;
+package br.com.justina.domain.repository.training;
 
 import br.com.justina.domain.model.training.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
+@Repository
 public interface QuestionRepository extends JpaRepository<Question, UUID> {
 }


### PR DESCRIPTION
## 🚀 Resumo
Refatoração na entidade `Question` e nos DTOs relacionados para tratar o campo `options` diretamente como uma **Lista de Strings** (`List<String>`), utilizando o suporte nativo do Hibernate 6 para JSONB.

Isso atende à solicitação da equipe para facilitar a integração com o Frontend, eliminando a necessidade de fazer *parse* manual de Strings JSON.

### 🛠️ Alterações Realizadas

#### 1. Domínio (Entity)
- **Classe `Question`:**
  - Alterado o tipo de `private String options` para `private List<String> options`.
  - Adicionada anotação `@JdbcTypeCode(SqlTypes.JSON)` para que o Hibernate converta automaticamente a lista Java para o formato `jsonb` do PostgreSQL.

#### 2. DTOs & Contratos
- **`CreateQuestionRequest`:** Agora aceita `List<String>` no payload de criação.
- **`QuestionResponse`:** Agora retorna `List<String>`, garantindo que o Frontend receba um array JSON válido e não uma string escapada.

#### 3. Manutenção (Cleanup)
- **`QuestionService`:** Ajustado para trafegar a lista diretamente.
- **Remoção de Duplicata:** Excluído arquivo `QuestionRepository.java` que estava na pasta incorreta, mantendo apenas a versão organizada dentro do pacote `training`.

### 🔄 Benefício (DX)
- **Antes:** O Frontend precisava enviar `"{ \"options\": \"[\\\"A\\\", \\\"B\\\"]\" }"`.
- **Agora:** O Frontend envia `"{ \"options\": [\"A\", \"B\"] }"`.

### ✅ Checklist
- [x] Build Backend (`mvn clean install`) - Sucesso.
- [x] Teste de persistência no PostgreSQL (Docker) validado.
- [x] Código limpo e sem duplicatas.